### PR TITLE
add specific ipware version to requirements

### DIFF
--- a/heliostats-requirements.txt
+++ b/heliostats-requirements.txt
@@ -18,6 +18,7 @@ django-axes==4.5.4
 django-dajaxice==0.7
 django-debug-toolbar==1.8
 django-extensions==1.9.0
+django-ipware==2.1.0
 django-nose==1.4.5
 django-passwords==0.3.12
 django-pci-auth==0.1.1

--- a/package.json
+++ b/package.json
@@ -1,74 +1,73 @@
 {
-    "name": "heliostats",
-    "version": "1.0.0",
-    "description": "1. Install virtualenvwrapper (see below) 2. `git clone git@bitbucket.org:kwh/heliostats.git` 3. `mkvirtualenv heliostats` (this will automatically then run `workon heliostats`, which activates the virtual env) 4. `pip install -r requirements.txt` 5. `createdb heliostats` 6. create file `heliostats/heliostats/settings/local.py` (use local_template.py as a template) 7. Set up your virtualenv hooks (See below) 8. `python manage.py migrate` 9. `python manage.py runserver`",
-    "main": "index.js",
-    "dependencies": {
-      "bootstrap": "^3.3.7",
-      "canvg": "^1.5.3",
-      "d3": "^5.7.0",
-      "datatables.net": "^1.10.19",
-      "datatables.net-dt": "^1.10.19",
-      "fixed-data-table-2": "^0.8.0",
-      "highcharts": "^6.2.0",
-      "html2pdf.js": "^0.9.0",
-      "isomorphic-fetch": "^2.2.1",
-      "jquery": "^3.3.1",
-      "js-cookie": "^2.1.4",
-      "numbro": "^2.1.1",
-      "papaparse": "^4.6.1",
-      "prop-types": "^15.5.10",
-      "react": "15.6.1",
-      "react-bootstrap": "^0.31.2",
-      "react-dom": "15.6.1",
-      "react-select": "^2.4.4",
-      "zxcvbn": "^4.4.2"
-    },
-    "devDependencies": {
-      "babel-core": "^6.25.0",
-      "babel-loader": "^7.1.1",
-      "babel-polyfill": "^6.23.0",
-      "babel-preset-env": "^1.6.0",
-      "babel-preset-es2015": "^6.24.1",
-      "babel-preset-react": "^6.24.1",
-      "babel-preset-stage-0": "^6.24.1",
-      "case-sensitive-paths-webpack-plugin": "^2.2.0",
-      "clean-webpack-plugin": "^0.1.17",
-      "css-loader": "^0.28.4",
-      "del": "^3.0.0",
-      "eslint": "^3.19.0",
-      "eslint-config-airbnb": "^15.0.2",
-      "eslint-plugin-import": "^2.7.0",
-      "eslint-plugin-jsx-a11y": "^5.1.1",
-      "eslint-plugin-react": "^7.1.0",
-      "extract-text-webpack-plugin": "^3.0.0",
-      "file-loader": "^0.11.2",
-      "jshint": "^2.9.5",
-      "style-loader": "^0.18.2",
-      "url-loader": "^0.5.9",
-      "webpack": "^3.5.6",
-      "webpack-bundle-tracker": "^0.2.0",
-      "webpack-merge": "^4.1.0",
-      "webpack-stream": "^4.0.0"
-    },
-    "scripts": {
-      "build": "webpack --config webpack.config.prod.js --profile",
-      "watch": "webpack --config webpack.config.dev.js --progress --colors --watch",
-      "test": "echo \"Error: no test specified\" && exit 1"
-    },
-    "repository": {
-      "type": "git",
-      "url": "git+ssh://git@bitbucket.org/kwh/heliostats.git"
-    },
-    "author": "",
-    "license": "ISC",
-    "homepage": "https://bitbucket.org/kwh/heliostats#readme",
-    "babel": {
-      "presets": [
-        "env",
-        "react",
-        "stage-0"
-      ]
-    }
+  "name": "heliostats",
+  "version": "1.0.0",
+  "description": "1. Install virtualenvwrapper (see below) 2. `git clone git@bitbucket.org:kwh/heliostats.git` 3. `mkvirtualenv heliostats` (this will automatically then run `workon heliostats`, which activates the virtual env) 4. `pip install -r requirements.txt` 5. `createdb heliostats` 6. create file `heliostats/heliostats/settings/local.py` (use local_template.py as a template) 7. Set up your virtualenv hooks (See below) 8. `python manage.py migrate` 9. `python manage.py runserver`",
+  "main": "index.js",
+  "dependencies": {
+    "bootstrap": "^3.3.7",
+    "canvg": "^1.5.3",
+    "d3": "^5.7.0",
+    "datatables.net": "^1.10.19",
+    "datatables.net-dt": "^1.10.19",
+    "fixed-data-table-2": "^0.8.0",
+    "highcharts": "^6.2.0",
+    "html2pdf.js": "^0.9.0",
+    "isomorphic-fetch": "^2.2.1",
+    "jquery": "^3.3.1",
+    "js-cookie": "^2.1.4",
+    "numbro": "^2.1.1",
+    "papaparse": "^4.6.1",
+    "prop-types": "^15.5.10",
+    "react": "15.6.1",
+    "react-bootstrap": "^0.31.2",
+    "react-dom": "15.6.1",
+    "react-select": "^2.4.4",
+    "zxcvbn": "^4.4.2"
+  },
+  "devDependencies": {
+    "babel-core": "^6.25.0",
+    "babel-loader": "^7.1.1",
+    "babel-polyfill": "^6.23.0",
+    "babel-preset-env": "^1.6.0",
+    "babel-preset-es2015": "^6.24.1",
+    "babel-preset-react": "^6.24.1",
+    "babel-preset-stage-0": "^6.24.1",
+    "case-sensitive-paths-webpack-plugin": "^2.2.0",
+    "clean-webpack-plugin": "^0.1.17",
+    "css-loader": "^0.28.4",
+    "del": "^3.0.0",
+    "eslint": "^3.19.0",
+    "eslint-config-airbnb": "^15.0.2",
+    "eslint-plugin-import": "^2.7.0",
+    "eslint-plugin-jsx-a11y": "^5.1.1",
+    "eslint-plugin-react": "^7.1.0",
+    "extract-text-webpack-plugin": "^3.0.0",
+    "file-loader": "^0.11.2",
+    "jshint": "^2.9.5",
+    "style-loader": "^0.18.2",
+    "url-loader": "^0.5.9",
+    "webpack": "^3.5.6",
+    "webpack-bundle-tracker": "^0.2.0",
+    "webpack-merge": "^4.1.0",
+    "webpack-stream": "^4.0.0"
+  },
+  "scripts": {
+    "build": "webpack --config webpack.config.prod.js --profile",
+    "watch": "webpack --config webpack.config.dev.js --progress --colors --watch",
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+ssh://git@bitbucket.org/kwh/heliostats.git"
+  },
+  "author": "",
+  "license": "ISC",
+  "homepage": "https://bitbucket.org/kwh/heliostats#readme",
+  "babel": {
+    "presets": [
+      "env",
+      "react",
+      "stage-0"
+    ]
   }
-  
+}


### PR DESCRIPTION
Updating the heliostats-requirements file in here to match the py3requirements.txt in the heliostats repo. The only change is to 'add a specific ipware version'.
This new image was also created in the hopes that a new image build might get apt + node back in sync with each other.