### PR TITLE
V5

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,8 @@ RUN pip install numpy==1.11.0
 RUN curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.33.0/install.sh | bash
 # set up NVM_DIR and load nvm
 ENV NVM_DIR /root/.nvm
-ENV NODE_VERSION 4.4.7
+# most recent LTS node version
+ENV NODE_VERSION 12.18.3
 
 RUN . $NVM_DIR/nvm.sh \
     && nvm install $NODE_VERSION \

--- a/heliostats-requirements.txt
+++ b/heliostats-requirements.txt
@@ -18,6 +18,7 @@ django-axes==4.5.4
 django-dajaxice==0.7
 django-debug-toolbar==1.8
 django-extensions==1.9.0
+django-ipware==2.1.0
 django-nose==1.4.5
 django-passwords==0.3.12
 django-pci-auth==0.1.1


### PR DESCRIPTION
Updates node to latest long-term-support version
This appears to have so far been successful in getting concourse pipelines to run.
(Why update all the way from 4.4.7 to 12.18.3?)
- npm packages were throwing `WARN!`ings about node being out of date. They wanted at least node 8+
- node 8 was end of life 2019/12/31
- Decided to update to latest LTS 12.18.3

I tested this image the following ways:
- Ran 4 concourse builds using this image - all successful
- Creating a local heliostats container from this image; heliostats appears to work in browser, no bugs encountered as of yet